### PR TITLE
Python 3 shebang

### DIFF
--- a/qu.py
+++ b/qu.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 from __future__ import print_function
 import argparse
 import sys


### PR DESCRIPTION
Update shebang to use `python3`.