### PR TITLE
Allow `-n` / `-s` with `-c`

### DIFF
--- a/qu.py
+++ b/qu.py
@@ -82,7 +82,15 @@ def main():
         tokens = ['"{}"'.format(i) for i in tokens]
 
     if args.comma:
-        delimiter = ', ' if args.space else ','
+        delimiter = ','
+
+        # space after comma (-c -s) or newline after comma (-c -n)
+        if args.space:
+            delimiter = ', '
+        elif args.newline:
+            delimiter = ',\n'
+
+        output = delimiter.join(tokens)
         output = delimiter.join(tokens)
     elif args.newline:
         output = '\n'.join(tokens)

--- a/qu.py
+++ b/qu.py
@@ -84,11 +84,11 @@ def main():
     if args.comma:
         delimiter = ','
 
-        # space after comma (-c -s) or newline after comma (-c -n)
-        if args.space:
-            delimiter = ', '
-        elif args.newline:
+        # newline after comman (-c -n) or space after comma (-c -s)
+        if args.newline:
             delimiter = ',\n'
+        elif args.space:
+            delimiter = ', '
 
         output = delimiter.join(tokens)
     elif args.newline:

--- a/qu.py
+++ b/qu.py
@@ -84,7 +84,7 @@ def main():
     if args.comma:
         delimiter = ','
 
-        # newline after comman (-c -n) or space after comma (-c -s)
+        # newline after comma (-c -n) or space after comma (-c -s)
         if args.newline:
             delimiter = ',\n'
         elif args.space:

--- a/qu.py
+++ b/qu.py
@@ -91,7 +91,6 @@ def main():
             delimiter = ',\n'
 
         output = delimiter.join(tokens)
-        output = delimiter.join(tokens)
     elif args.newline:
         output = '\n'.join(tokens)
     # Splunk OR style

--- a/qu.py
+++ b/qu.py
@@ -82,7 +82,8 @@ def main():
         tokens = ['"{}"'.format(i) for i in tokens]
 
     if args.comma:
-        output = ','.join(tokens)
+        delimiter = ', ' if args.space else ','
+        output = delimiter.join(tokens)
     elif args.newline:
         output = '\n'.join(tokens)
     # Splunk OR style


### PR DESCRIPTION
This PR allows `-n` (newline) or `-s` (space) with `-c` (comma).

## Before

```sh
➜  ~ echo "foo,bar,baz" | qu -cs -q2
"foo","bar","baz"
➜  ~ echo "foo,bar,baz" | qu -cn -q1
'foo','bar','baz'
```

## After

```sh
➜  ~ echo "foo,bar,baz" | qu -cs -q2
"foo", "bar", "baz"
➜  ~ echo "foo,bar,baz" | qu -cn -q1
'foo',
'bar',
'baz'
➜  ~ echo "foo,bar,baz" | qu -c -q2  # confirming -n/-s is optional
"foo","bar","baz"
```

